### PR TITLE
Open footer credit in new tab.

### DIFF
--- a/twentytwenty/footer.php
+++ b/twentytwenty/footer.php
@@ -30,7 +30,7 @@
             </p><!-- .footer-copyright -->
 
             <p class="powered-by-wordpress">
-                <a href="<?php echo esc_url(__('https://creatingdrew.com', 'twentytwenty')); ?>">
+                <a href="<?php echo esc_url(__('https://creatingdrew.com', 'twentytwenty')); ?>" target="_blank">
                     <?php _e('Made with ❤️ by Drew Douglass', 'twentytwenty'); ?>
                 </a>
             </p><!-- .powered-by-wordpress -->


### PR DESCRIPTION
Opens link in the footer in a new tab. Still needs to have a fix added detailed in issue #6 